### PR TITLE
update the broker for ad_impression

### DIFF
--- a/ad-ctr/config.yaml
+++ b/ad-ctr/config.yaml
@@ -11,6 +11,6 @@ connectors:
       timeout_ms: 10000
   ad_impression:
     kafka:
-      broker: redpanda:9092
+      broker: message_queue:9092
       topic: ad_impression
       timeout_ms: 10000


### PR DESCRIPTION
The broker value for ad_click was updated, but the broker value for ad_impression was not. I just updated it in the config/yaml for ad-ctr