### PR TITLE
Use v1.0.1

### DIFF
--- a/ad-click/docker-compose.yml
+++ b/ad-click/docker-compose.yml
@@ -313,7 +313,7 @@ services:
       timeout: 5s
       retries: 5
   datagen:
-    image: ghcr.io/singularity-data/demo-datagen:v1.0.0
+    image: ghcr.io/singularity-data/demo-datagen:v1.0.1
     depends_on: [message_queue]
     command:
       - /bin/sh

--- a/ad-ctr/docker-compose.yml
+++ b/ad-ctr/docker-compose.yml
@@ -313,7 +313,7 @@ services:
       timeout: 5s
       retries: 5
   datagen:
-    image: ghcr.io/singularity-data/demo-datagen:v1.0.0
+    image: ghcr.io/singularity-data/demo-datagen:v1.0.1
     depends_on: [message_queue]
     command:
       - /bin/sh


### PR DESCRIPTION
The size of `datagen` is small. How about always using the latest one?