### PR TITLE
add a data generator for delivery example

### DIFF
--- a/datagen/Dockerfile
+++ b/datagen/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang as builder
 
 ADD . /datagen-src
-RUN cd /datagen-src && go build
+RUN cd /datagen-src && gofmt -s -w . && go build
 
 FROM ubuntu:20.04
 

--- a/datagen/delivery/delivery.go
+++ b/datagen/delivery/delivery.go
@@ -1,0 +1,71 @@
+package delivery
+
+import (
+	"context"
+	"datagen/gen"
+	"datagen/sink"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"time"
+)
+
+type orderEvent struct {
+	OrderId        int64  `json:"order_id"`
+	RestaurantId   int64  `json:"restaurant_id"`
+	OrderState     string `json:"order_state"`
+	OrderTimestamp string `json:"order_timestamp"`
+}
+
+func (r *orderEvent) ToPostgresSql() string {
+	return fmt.Sprintf("INSERT INTO %s (order_id, restaurant_id, order_state, order_timestamp) values ('%d', '%d', '%s', '%s')",
+		"delivery_orders_source", r.OrderId, r.RestaurantId, r.OrderState, r.OrderTimestamp)
+}
+
+func (r *orderEvent) ToKafka() (topic string, data []byte) {
+	data, _ = json.Marshal(r)
+	return "delivery_orders", data
+}
+
+type orderEventGen struct {
+	seqOrderId int64
+	cfg        gen.GeneratorConfig
+}
+
+func NewOrderEventGen(cfg gen.GeneratorConfig) gen.LoadGenerator {
+	return &orderEventGen{
+		seqOrderId: 0,
+		cfg:        cfg,
+	}
+}
+
+func (g *orderEventGen) KafkaTopics() []string {
+	return []string{"delivery_orders"}
+}
+
+func (g *orderEventGen) Load(ctx context.Context, outCh chan<- sink.SinkRecord) {
+	order_states := []string{
+		"CREATED",
+		"PENDING",
+		"DELIVERED",
+	}
+
+	var num_of_restaurants int64 = 3
+	var total_minutes = 30
+
+	for {
+		now := time.Now()
+		record := &orderEvent{
+			OrderId:        g.seqOrderId,
+			RestaurantId:   rand.Int63n(num_of_restaurants),
+			OrderState:     order_states[rand.Intn(len(order_states))],
+			OrderTimestamp: now.Add(time.Duration(rand.Intn(total_minutes)) * time.Minute).Format(gen.RwTimestampLayout),
+		}
+		g.seqOrderId++
+		select {
+		case <-ctx.Done():
+			return
+		case outCh <- record:
+		}
+	}
+}

--- a/datagen/main.go
+++ b/datagen/main.go
@@ -117,7 +117,7 @@ func main() {
 			},
 			cli.StringFlag{
 				Name:        "mode",
-				Usage:       "ad-click or ad-ctr",
+				Usage:       "ad-click or ad-ctr or twitter or cdn-metrics or clickstream or ecommerce or delivery",
 				Required:    true,
 				Destination: &cfg.Mode,
 			},

--- a/datagen/sink/kafka/kafka.go
+++ b/datagen/sink/kafka/kafka.go
@@ -71,13 +71,6 @@ func CreateRequiredTopics(admin sarama.ClusterAdmin, keys []string) error {
 	if err != nil {
 		return err
 	}
-	if len(topics) != 0 {
-		var topicNames []string
-		for k := range topics {
-			topicNames = append(topicNames, k)
-		}
-		log.Printf("Existing topics: %s", topicNames)
-	}
 	for _, t := range keys {
 		if err := createTopic(admin, t, topics); err != nil {
 			return err

--- a/datagen/sink/kafka/kafka.go
+++ b/datagen/sink/kafka/kafka.go
@@ -12,7 +12,9 @@ import (
 )
 
 type KafkaSink struct {
-	client sarama.AsyncProducer
+	admin   sarama.ClusterAdmin
+	brokers string
+	client  sarama.AsyncProducer
 }
 
 func newKafkaConfig() *sarama.Config {
@@ -29,11 +31,25 @@ func newKafkaConfig() *sarama.Config {
 }
 
 func OpenKafkaSink(ctx context.Context, brokers string) (*KafkaSink, error) {
+	admin, err := sarama.NewClusterAdmin(strings.Split(brokers, ","), newKafkaConfig())
+	topics, err := admin.ListTopics()
+	if err != nil {
+		return nil, err
+	}
+	var topicNames []string
+	for k := range topics {
+		topicNames = append(topicNames, k)
+	}
+	log.Printf("Existing topics: %s", topicNames)
 	client, err := sarama.NewAsyncProducer(strings.Split(brokers, ","), newKafkaConfig())
 	if err != nil {
 		return nil, fmt.Errorf("NewAsyncProducer failed: %v", err)
 	}
-	p := &KafkaSink{client: client}
+	p := &KafkaSink{
+		admin:   admin,
+		brokers: brokers,
+		client:  client,
+	}
 	go func() {
 		p.consumeSuccesses(ctx)
 	}()
@@ -50,11 +66,7 @@ func (p *KafkaSink) consumeSuccesses(ctx context.Context) {
 	}
 }
 
-func CreateRequiredTopics(brokers string, keys []string) error {
-	admin, err := sarama.NewClusterAdmin(strings.Split(brokers, ","), newKafkaConfig())
-	if err != nil {
-		return err
-	}
+func CreateRequiredTopics(admin sarama.ClusterAdmin, keys []string) error {
 	topics, err := admin.ListTopics()
 	if err != nil {
 		return err
@@ -86,6 +98,10 @@ func createTopic(admin sarama.ClusterAdmin, key string, topics map[string]sarama
 		NumPartitions:     16,
 		ReplicationFactor: 1,
 	}, false)
+}
+
+func (p *KafkaSink) Prepare(topics []string) error {
+	return CreateRequiredTopics(p.admin, topics)
 }
 
 func (p *KafkaSink) Close() error {

--- a/datagen/sink/postgres/postgres.go
+++ b/datagen/sink/postgres/postgres.go
@@ -27,6 +27,10 @@ func OpenPostgresSink(cfg PostgresConfig) (*PostgresSink, error) {
 	return &PostgresSink{db}, nil
 }
 
+func (p *PostgresSink) Prepare(topics []string) error {
+	return nil
+}
+
 func (p *PostgresSink) Close() error {
 	return p.db.Close()
 }

--- a/datagen/sink/pulsar/pulsar.go
+++ b/datagen/sink/pulsar/pulsar.go
@@ -26,6 +26,10 @@ func OpenPulsarSink(ctx context.Context, brokers string) (*PulsarSink, error) {
 	}, nil
 }
 
+func (p *PulsarSink) Prepare(topics []string) error {
+	return nil
+}
+
 func (p *PulsarSink) Close() error {
 	p.client.Close()
 	return nil

--- a/datagen/sink/sink.go
+++ b/datagen/sink/sink.go
@@ -14,6 +14,8 @@ type SinkRecord interface {
 }
 
 type Sink interface {
+	Prepare(topics []string) error
+
 	WriteRecord(ctx context.Context, record SinkRecord) error
 
 	Close() error


### PR DESCRIPTION
Previously, we do not explicitly create the topic before writing records into the topic.

On my local machine, sometimes some topics will be created automatically when writing records in the topic, sometimes some topics will not.

So we explicitly create necessary topics for the example.

This PR adds a data generator.
After I tag it and push the image onto GitHub, then I will add the SQL and docker-compose.yml for delivery example in the next PR.

I have tested that it can run successfully with query:
```
CREATE SOURCE delivery_orders_source (
    order_id BIGINT,
    restaurant_id BIGINT,
    order_state VARCHAR,
    order_timestamp TIMESTAMP
) WITH (
    'connector' = 'kafka',
    'kafka.topic' = 'delivery_orders',
    'kafka.brokers' = 'message_queue:29092',
    'kafka.scan.startup.mode' = 'earliest'
) ROW FORMAT JSON;


CREATE MATERIALIZED VIEW restaurant_orders AS
SELECT
    window_start,
    restaurant_id,
    COUNT(*) AS total_order
FROM 
    HOP(delivery_orders_source, order_timestamp, INTERVAL '1' MINUTE, INTERVAL '15' MINUTE)
WHERE 
    order_state = 'CREATED'
GROUP BY
    restaurant_id,
    window_start
ORDER BY
    restaurant_id,
    window_start;
```