### PR TITLE
cdn-metrics: increase prob of tailed cases

### DIFF
--- a/ad-click/docker-compose.yml
+++ b/ad-click/docker-compose.yml
@@ -2,7 +2,7 @@
 version: "3"
 services:
   compactor-0:
-    image: "ghcr.io/singularity-data/risingwave:v0.1.10"
+    image: "ghcr.io/singularity-data/risingwave:v0.1.11"
     command:
       - compactor-node
       - "--host"
@@ -39,7 +39,7 @@ services:
       timeout: 5s
       retries: 5
   compute-node-0:
-    image: "ghcr.io/singularity-data/risingwave:v0.1.10"
+    image: "ghcr.io/singularity-data/risingwave:v0.1.11"
     command:
       - compute-node
       - "--host"
@@ -121,7 +121,7 @@ services:
       timeout: 5s
       retries: 5
   frontend-node-0:
-    image: "ghcr.io/singularity-data/risingwave:v0.1.10"
+    image: "ghcr.io/singularity-data/risingwave:v0.1.11"
     command:
       - frontend-node
       - "--host"
@@ -173,7 +173,7 @@ services:
       timeout: 5s
       retries: 5
   meta-node-0:
-    image: "ghcr.io/singularity-data/risingwave:v0.1.10"
+    image: "ghcr.io/singularity-data/risingwave:v0.1.11"
     command:
       - meta-node
       - "--listen-addr"

--- a/ad-ctr/docker-compose.yml
+++ b/ad-ctr/docker-compose.yml
@@ -2,7 +2,7 @@
 version: "3"
 services:
   compactor-0:
-    image: "ghcr.io/singularity-data/risingwave:v0.1.10"
+    image: "ghcr.io/singularity-data/risingwave:v0.1.11"
     command:
       - compactor-node
       - "--host"
@@ -39,7 +39,7 @@ services:
       timeout: 5s
       retries: 5
   compute-node-0:
-    image: "ghcr.io/singularity-data/risingwave:v0.1.10"
+    image: "ghcr.io/singularity-data/risingwave:v0.1.11"
     command:
       - compute-node
       - "--host"
@@ -121,7 +121,7 @@ services:
       timeout: 5s
       retries: 5
   frontend-node-0:
-    image: "ghcr.io/singularity-data/risingwave:v0.1.10"
+    image: "ghcr.io/singularity-data/risingwave:v0.1.11"
     command:
       - frontend-node
       - "--host"
@@ -173,7 +173,7 @@ services:
       timeout: 5s
       retries: 5
   meta-node-0:
-    image: "ghcr.io/singularity-data/risingwave:v0.1.10"
+    image: "ghcr.io/singularity-data/risingwave:v0.1.11"
     command:
       - meta-node
       - "--listen-addr"

--- a/cdn-metrics/docker-compose.yml
+++ b/cdn-metrics/docker-compose.yml
@@ -2,7 +2,7 @@
 version: "3"
 services:
   compactor-0:
-    image: "ghcr.io/singularity-data/risingwave:v0.1.10"
+    image: "ghcr.io/singularity-data/risingwave:v0.1.11"
     command:
       - compactor-node
       - "--host"
@@ -39,7 +39,7 @@ services:
       timeout: 5s
       retries: 5
   compute-node-0:
-    image: "ghcr.io/singularity-data/risingwave:v0.1.10"
+    image: "ghcr.io/singularity-data/risingwave:v0.1.11"
     command:
       - compute-node
       - "--host"
@@ -121,7 +121,7 @@ services:
       timeout: 5s
       retries: 5
   frontend-node-0:
-    image: "ghcr.io/singularity-data/risingwave:v0.1.10"
+    image: "ghcr.io/singularity-data/risingwave:v0.1.11"
     command:
       - frontend-node
       - "--host"
@@ -173,7 +173,7 @@ services:
       timeout: 5s
       retries: 5
   meta-node-0:
-    image: "ghcr.io/singularity-data/risingwave:v0.1.10"
+    image: "ghcr.io/singularity-data/risingwave:v0.1.11"
     command:
       - meta-node
       - "--listen-addr"
@@ -313,12 +313,12 @@ services:
       timeout: 5s
       retries: 5
   datagen:
-    image: ghcr.io/singularity-data/demo-datagen:v1.0.4
+    image: ghcr.io/singularity-data/demo-datagen:v1.0.6
     depends_on: [message_queue]
     command:
       - /bin/sh
       - -c
-      - /datagen --mode cdn-metrics --qps 2 kafka --brokers message_queue:29092
+      - /datagen --heavytail --mode cdn-metrics --qps 1000 kafka --brokers message_queue:29092
     restart: always
     container_name: datagen
 volumes:

--- a/clickstream/docker-compose.yml
+++ b/clickstream/docker-compose.yml
@@ -2,7 +2,7 @@
 version: "3"
 services:
   compactor-0:
-    image: "ghcr.io/singularity-data/risingwave:v0.1.10"
+    image: "ghcr.io/singularity-data/risingwave:v0.1.11"
     command:
       - compactor-node
       - "--host"
@@ -39,7 +39,7 @@ services:
       timeout: 5s
       retries: 5
   compute-node-0:
-    image: "ghcr.io/singularity-data/risingwave:v0.1.10"
+    image: "ghcr.io/singularity-data/risingwave:v0.1.11"
     command:
       - compute-node
       - "--host"
@@ -121,7 +121,7 @@ services:
       timeout: 5s
       retries: 5
   frontend-node-0:
-    image: "ghcr.io/singularity-data/risingwave:v0.1.10"
+    image: "ghcr.io/singularity-data/risingwave:v0.1.11"
     command:
       - frontend-node
       - "--host"
@@ -173,7 +173,7 @@ services:
       timeout: 5s
       retries: 5
   meta-node-0:
-    image: "ghcr.io/singularity-data/risingwave:v0.1.10"
+    image: "ghcr.io/singularity-data/risingwave:v0.1.11"
     command:
       - meta-node
       - "--listen-addr"

--- a/datagen/cdn_metrics/cdn_metrics.go
+++ b/datagen/cdn_metrics/cdn_metrics.go
@@ -7,10 +7,11 @@ import (
 )
 
 type cdnMetricsGen struct {
+	cfg gen.GeneratorConfig
 }
 
-func NewCdnMetricsGen() gen.LoadGenerator {
-	return &cdnMetricsGen{}
+func NewCdnMetricsGen(cfg gen.GeneratorConfig) gen.LoadGenerator {
+	return &cdnMetricsGen{cfg: cfg}
 }
 
 func (g *cdnMetricsGen) KafkaTopics() []string {
@@ -20,11 +21,11 @@ func (g *cdnMetricsGen) KafkaTopics() []string {
 func (g *cdnMetricsGen) Load(ctx context.Context, outCh chan<- sink.SinkRecord) {
 	for i := 0; i < 10; i++ { // Assume there are 10 devices
 		go func(i int) {
-			m := newDeviceTcpMonitor(i)
+			m := newDeviceTcpMonitor(i, g.cfg)
 			m.emulate(ctx, outCh)
 		}(i)
 		go func(i int) {
-			m := newDeviceNicsMonitor(i)
+			m := newDeviceNicsMonitor(i, g.cfg)
 			m.emulate(ctx, outCh)
 		}(i)
 	}

--- a/datagen/gen/generator.go
+++ b/datagen/gen/generator.go
@@ -7,6 +7,8 @@ import (
 	"datagen/sink/kinesis"
 	"datagen/sink/postgres"
 	"datagen/sink/pulsar"
+
+	"gonum.org/v1/gonum/stat/distuv"
 )
 
 type GeneratorConfig struct {
@@ -23,6 +25,10 @@ type GeneratorConfig struct {
 	Sink string
 	// The throttled requests-per-second.
 	Qps int
+
+	// Whether the tail probability is high.
+	// If true, We will use uniform distribution for randomizing values.
+	HeavyTail bool
 }
 
 type LoadGenerator interface {
@@ -32,3 +38,36 @@ type LoadGenerator interface {
 }
 
 const RwTimestampLayout = "2006-01-02 15:04:05.07"
+
+type RandDist interface {
+	// Rand returns a random number ranging from [0, max].
+	Rand(max float64) float64
+}
+
+func NewRandDist(cfg GeneratorConfig) RandDist {
+	if cfg.HeavyTail {
+		return UniformDist{}
+	} else {
+		return PoissonDist{}
+	}
+}
+
+type UniformDist struct{}
+
+func (UniformDist) Rand(max float64) float64 {
+	d := distuv.Uniform{
+		Min: 0,
+		Max: max,
+	}
+	return d.Rand()
+}
+
+// A more real-world distribution. The tail will have lower probability..
+type PoissonDist struct{}
+
+func (PoissonDist) Rand(max float64) float64 {
+	d := distuv.Poisson{
+		Lambda: max / 2,
+	}
+	return d.Rand()
+}

--- a/datagen/load_gen.go
+++ b/datagen/load_gen.go
@@ -45,7 +45,7 @@ func newGen(cfg gen.GeneratorConfig) (gen.LoadGenerator, error) {
 	} else if cfg.Mode == "twitter" {
 		return twitter.NewTwitterGen(), nil
 	} else if cfg.Mode == "cdn-metrics" {
-		return cdn_metrics.NewCdnMetricsGen(), nil
+		return cdn_metrics.NewCdnMetricsGen(cfg), nil
 	} else if cfg.Mode == "clickstream" {
 		return clickstream.NewClickStreamGen(), nil
 	} else if cfg.Mode == "ecommerce" {

--- a/datagen/main.go
+++ b/datagen/main.go
@@ -143,6 +143,12 @@ func main() {
 				Required:    true,
 				Destination: &cfg.Mode,
 			},
+			cli.BoolFlag{
+				Name:        "heavytail",
+				Usage:       "Whether the tail probability is high. If true We will use uniform distribution for randomizing values.",
+				Required:    false,
+				Destination: &cfg.HeavyTail,
+			},
 		},
 	}
 	err := app.Run(os.Args)

--- a/delivery/docker-compose.yml
+++ b/delivery/docker-compose.yml
@@ -2,7 +2,7 @@
 version: "3"
 services:
   compactor-0:
-    image: "ghcr.io/singularity-data/risingwave:v0.1.10"
+    image: "ghcr.io/singularity-data/risingwave:v0.1.11"
     command:
       - compactor-node
       - "--host"
@@ -39,7 +39,7 @@ services:
       timeout: 5s
       retries: 5
   compute-node-0:
-    image: "ghcr.io/singularity-data/risingwave:v0.1.10"
+    image: "ghcr.io/singularity-data/risingwave:v0.1.11"
     command:
       - compute-node
       - "--host"
@@ -121,7 +121,7 @@ services:
       timeout: 5s
       retries: 5
   frontend-node-0:
-    image: "ghcr.io/singularity-data/risingwave:v0.1.10"
+    image: "ghcr.io/singularity-data/risingwave:v0.1.11"
     command:
       - frontend-node
       - "--host"
@@ -173,7 +173,7 @@ services:
       timeout: 5s
       retries: 5
   meta-node-0:
-    image: "ghcr.io/singularity-data/risingwave:v0.1.10"
+    image: "ghcr.io/singularity-data/risingwave:v0.1.11"
     command:
       - meta-node
       - "--listen-addr"

--- a/twitter/docker-compose.yml
+++ b/twitter/docker-compose.yml
@@ -2,7 +2,7 @@
 version: "3"
 services:
   compactor-0:
-    image: "ghcr.io/singularity-data/risingwave:nightly-20220718"
+    image: "ghcr.io/singularity-data/risingwave:v0.1.11"
     command:
       - compactor-node
       - "--host"
@@ -39,7 +39,7 @@ services:
       timeout: 5s
       retries: 5
   compute-node-0:
-    image: "ghcr.io/singularity-data/risingwave:nightly-20220718"
+    image: "ghcr.io/singularity-data/risingwave:v0.1.11"
     command:
       - compute-node
       - "--host"
@@ -121,7 +121,7 @@ services:
       timeout: 5s
       retries: 5
   frontend-node-0:
-    image: "ghcr.io/singularity-data/risingwave:nightly-20220718"
+    image: "ghcr.io/singularity-data/risingwave:v0.1.11"
     command:
       - frontend-node
       - "--host"
@@ -173,7 +173,7 @@ services:
       timeout: 5s
       retries: 5
   meta-node-0:
-    image: "ghcr.io/singularity-data/risingwave:nightly-20220718"
+    image: "ghcr.io/singularity-data/risingwave:v0.1.11"
     command:
       - meta-node
       - "--listen-addr"


### PR DESCRIPTION
1. Upgraded risingwave to 0.1.11. 
2. Increase the probability of tailed cases, i.e. the anomalies of tcp. 