### PR TITLE
fix: link to ad-ctr tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Here is a gallery of demos that present how to use RisingWave alongwith the ecosystem tools.
 
 - `ad-click/`: [Build and Maintain Real-time Applications Faster and Easier with Redpanda and RisingWave](https://singularity-data.com/blog/build-with-Redpanda-and-RisingWave)
-- `ad-ctr`: [Perform real-time ad performance analysis](https://www.risingwave.dev/docs/latest/perform-real-time-ad-performance-analysis/)
+- `ad-ctr`: [Perform real-time ad performance analysis](https://www.risingwave.dev/docs/latest/real-time-ad-performance-analysis/)
 
 ## Workload Generator
 


### PR DESCRIPTION
Fixes reference to the tutorial broken by a recent update to the docs site.